### PR TITLE
Resolve #22, load all images/layers into RAM 

### DIFF
--- a/Paco_classifier/preprocess.py
+++ b/Paco_classifier/preprocess.py
@@ -19,7 +19,18 @@ def getMaskFromRegion(region_path):
 def preprocess(inputs, batch_size, patch_height, patch_width, number_samples_per_class):
     """
     Run a bunch of preprocessing steps in this function. Currently we have:
-    1. extract X/Y/W/H from region mask and crop images and layers first
+    1. Extract X/Y/W/H from the region mask and crop images and layers first
+    2. The image width/height should be not less than the patch width/height.
+    3. Keep a list to save the indices of nonempty layers. The model is trained on nonempty layers.
+    4. Track the number of empty layers. It should be less than the number of images 
+        (at least one trainable data).
+
+    Return:
+        {<rodan port name>:[[np.ndarray, ...], [int, int, ...]]}
+            A dictionary with the rodan port names ('Image', 'rgba PNG - Layer 0 (Background)', ...)
+            as keys and lists of two lists as their items.
+            1st list: processed/cropped loaded images/layers represented as np.ndarray with shape (W, H, 3, dtype=float) or (W, H, dtyp=bool)
+            2nd list: the indices of nonempty layers. The list is empty in dict['Image']
     """
     # Check if batch size is less than number of samples per class
     logging.info("Checking batch size")

--- a/fast_calvo_easy_training.py
+++ b/fast_calvo_easy_training.py
@@ -260,7 +260,7 @@ outputs = init_output_dictionary(config)
 
 # Sanity check
 print ("Start preprocess")
-preprocess.preprocess(inputs, config.batch_size, config.patch_height, config.patch_width, config.number_samples_per_class)
+layer_dict = preprocess.preprocess(inputs, config.batch_size, config.patch_height, config.patch_width, config.number_samples_per_class)
 print ("After pre_training_check")
 
 input_ports = len([x for x in inputs if "Layer" in x])
@@ -281,7 +281,7 @@ for i in range(input_ports):
 
 # Call in training function
 status = training.train_msae(
-    inputs=inputs,
+    inputs=layer_dict,
     num_labels=input_ports,
     height=config.patch_height,
     width=config.patch_width,


### PR DESCRIPTION
Resolve #22 

Since we got lots of RAM on staging/production, this PR loads/preprocesses images `(W, H, 3, dtype=float)`/layers `(W, H, dtype=bool)` into RAM in preprocessing steps. This removes the IO time (cv2.imread) needed in each step. The loaded images/layers are saved in a dictionary. 

`W` and `H` are the width and height of the selected region.