### PR TITLE
Fix #28, Dynamic load X/Y pair into RAM

### DIFF
--- a/Paco_classifier/data_loader.py
+++ b/Paco_classifier/data_loader.py
@@ -1,6 +1,7 @@
-from enum import Enum	
-import random as rd	
+from enum import Enum
+import random as rd
 import threading	
+from typing import Optional
 
 import numpy as np
 
@@ -59,6 +60,194 @@ def threadsafe_generator(f):
 
     return g
 
+class Data():
+    def __init__(self, x_name:str, path:str, size:Optional[int] = None, count:int=0):
+        self.x_name = x_name # Only for Y
+        self.path = path
+        self.size = size
+        self.img = None
+        self.count = count # Only for Y
+
+    def loadImg(self):
+        self.img = np.load(self.path)
+
+    def delImg(self):
+        del self.img
+        self.img = None
+
+    def hasImg(self):
+        return isinstance(self.img, np.ndarray)
+
+    def __eq__(self, other):
+        return other.path == self.path
+
+
+class DataContainer():
+    def __init__(self, ram_limit:int):
+        self.meta = {"Image":{}}
+        self.ram_limit = ram_limit
+        self.current_ram = 0
+
+    def _getCurrentRAM(self, layer_name:str):
+        image_list = self.meta["Image"]
+        rams = [y.size + image_list[y.x_name].size for y in self.meta[layer_name]["working"]]
+        return sum(rams)
+
+    def addXYPair(self, x_name:str, layer_name:str, x:Data, y:Data):
+        # append x
+        if x_name not in self.meta["Image"].keys():
+            self.meta["Image"][x_name] = x
+
+        # append y
+        if layer_name not in self.meta.keys():
+            self.meta[layer_name] = {"working":[], "pending":[]}
+        self.meta[layer_name]["pending"].append(y)
+
+    def reloadPendingList(self, layer_name:str):
+        assert len(self.meta[layer_name]["working"]) != 0
+
+        pending_list = self.meta[layer_name]["pending"]
+        working_list = self.meta[layer_name]["working"]
+
+        # Extract the last Y from the pending list and put it in the working list
+        pending_list_pop_idx = 0
+        if len(pending_list) != 0:
+            # Pop the last Y from the pending liist
+            new_Y:Data = pending_list[pending_list_pop_idx]
+            new_X:Data = self.meta["Image"][new_Y.x_name]
+            assert new_X.hasImg() == False, "Memory Leak: The x.img of data ({}) in pending list is not None".format(new_Y.path) 
+            assert new_Y.hasImg() == False, "Memory Leak: The y.img of data ({}) in pending list is not None".format(new_Y.path) 
+            
+            required_ram = new_Y.size + new_X.size
+
+            # Remove Xs/Ys in working list to get enough space to load new X/Y
+            rd.shuffle(working_list)
+            released_ram = 0
+            removed_from_working_list = []
+            while released_ram < required_ram and len(working_list) > 0:
+                old_Y:Data = working_list.pop()
+                old_X:Data = self.meta["Image"][old_Y.x_name]
+
+                released_ram += old_Y.size + old_X.size
+                old_Y.delImg()
+                old_X.delImg()
+                removed_from_working_list.append(old_Y)
+
+            # We've removed all Xs/Ys in the working list but still need more RAM.
+            if len(working_list) == 0 and self.ram_limit - self.current_ram + released_ram < required_ram:
+                working_list += removed_from_working_list
+                for Y in working_list:
+                    X:Data = self.meta["Image"][Y.x_name]
+                    X.loadImg()
+                    Y.loadImg()
+                raise ValueError("Not enought RAM, Release {} RAM but require {} RAM.".format(released_ram, required_ram))
+
+            # Now load X/Y and move Y into moving list
+            new_Y.loadImg()
+            new_X.loadImg()
+            working_list.append(new_Y)
+            pending_list.pop(pending_list_pop_idx)
+
+            self.current_ram -= released_ram
+            self.current_ram += required_ram
+
+            # Move data removed from the working list into pending list
+            pending_list += removed_from_working_list
+
+            # Load more images from the pending list to fill up the remaining RAM
+            remaining_ram = released_ram - required_ram
+            head_path = ""
+            while len(pending_list) != 0:
+                Y:Data = pending_list[-1]
+                X:Data = self.meta["Image"][Y.x_name]
+                required_ram = Y.size + X.size
+
+                # Y fits to the RAM. Move it into the working list
+                if required_ram < remaining_ram:
+                    X.loadImg()
+                    Y.loadImg()
+                    self.meta[layer_name]["working"].append(Y)
+
+                    pending_list.pop()
+                    remaining_ram -= required_ram
+                else:
+                    # The first time we get sth that does not fit into RAM. Keep track of its path
+                    if len(head_path) == 0:
+                        head_path = Y.path
+                        pending_list.insert(0, Y)
+                        pending_list.pop()
+                    else:
+                        # All images in the pending list can't fit into RAM.
+                        if head_path == Y.path:
+                            break
+                        else:
+                            # else we just pop the data and push it back
+                            pending_list.insert(0, Y)
+                            pending_list.pop()
+
+        # Update count
+        for Y in pending_list:
+            Y.count += 1
+
+        assert self.ram_limit > self._getCurrentRAM(layer_name), "Exceed RAM limit: {} with loading {} RAM".format(self.ram_limit, self._getCurrentRAM(layer_name))
+
+
+    def initWorkingList(self, layer_name:str):
+        # Try to load all Ys in the pending list
+        assert len(self.meta[layer_name]["working"]) == 0
+        assert self.current_ram == 0
+
+        pending_list = self.meta[layer_name]["pending"]
+        required_ram = 0
+        head_path = ""
+        while len(pending_list) != 0:
+            Y:Data = pending_list[-1]
+            X:Data = self.meta["Image"][Y.x_name]
+            required_ram = Y.size + X.size
+
+            # The first time we get sth that does not fit into RAM. Keep track of its path
+            if required_ram + self.current_ram < self.ram_limit:
+                X.loadImg()
+                Y.loadImg()
+                self.meta[layer_name]["working"].append(Y)
+
+                pending_list.pop()
+                self.current_ram += required_ram
+            else:
+                # All images in the pending list can't fit into RAM.
+                if len(head_path) == 0:
+                    head_path = Y.path
+                    pending_list.insert(0, Y)
+                    pending_list.pop()
+                else:
+                    # Break if we meet the head again
+                    if head_path == Y.path:
+                        break
+                    else:
+                        # else we just pop the data and push it back
+                        pending_list.insert(0, Y)
+                        pending_list.pop()
+
+        # All Xs/Ys exceed the memory limit
+        if len(self.meta[layer_name]["working"]) == 0:
+            raise ValueError(f"Require {required_ram} Gb RAM and exceed the limit {self.ram_limit} Gb RAM.")
+
+        # Update count
+        for Y in pending_list:
+            Y.count += 1
+    
+    def delWorkingList(self, layer_name:str):
+        working_list = self.meta[layer_name]["working"]
+        while len(working_list) != 0:
+            Y:Data = working_list.pop()
+            X:Data = self.meta["Image"][Y.x_name]
+
+            X.delImg()
+            Y.delImg()
+            self.meta[layer_name]["pending"].append(Y)
+        self.current_ram = 0
+
+
 def appendNewSample(gr, gt, row, col, patch_height, patch_width, gr_chunks, gt_chunks, index):
     gr_sample = gr[
             row : row + patch_height, col : col + patch_width
@@ -97,8 +286,9 @@ def extractRandomSamplesClass(gr, gt, patch_height, patch_width, batch_size, gr_
 
 
 def extractRandomSamples(inputs, idx_file, idx_label, patch_height, patch_width, batch_size, sample_extraction_mode):
-    gr = inputs["Image"][0][idx_file]
-    gt = inputs[idx_label][0][idx_file]
+    gt = inputs.meta[idx_label]["working"][idx_file].img
+    gr_name = inputs.meta[idx_label]["working"][idx_file].x_name
+    gr = inputs.meta["Image"][gr_name].img
 
     gr_chunks = np.zeros(shape=(batch_size, patch_width, patch_height, 3))
     gt_chunks = np.zeros(shape=(batch_size, patch_width, patch_height))
@@ -119,8 +309,9 @@ def createGeneratorSequentialExtraction(inputs, idx_file, idx_label, patch_heigh
     gr_chunks = np.zeros(shape=(batch_size, patch_width, patch_height, 3))
     gt_chunks = np.zeros(shape=(batch_size, patch_width, patch_height))
 
-    gr = inputs["Image"][0][idx_file]
-    gt = inputs[idx_label][0][idx_file]
+    gt = inputs.meta[idx_label]["working"][idx_file].img
+    gr_name = inputs.meta[idx_label]["working"][idx_file].x_name
+    gr = inputs.meta["Image"][gr_name].img
     count = 0
     for row in range(0, gr.shape[0] - patch_height, hstride):
         for col in range(0, gr.shape[1] - patch_width, wstride):
@@ -133,31 +324,40 @@ def createGeneratorSequentialExtraction(inputs, idx_file, idx_label, patch_heigh
                 count = 0
 
 @threadsafe_generator  # Credit: https://anandology.com/blog/using-iterators-and-generators/
-def createGenerator(inputs, idx_label, patch_height, patch_width, batch_size, file_selection_mode, sample_extraction_mode):
+def createGenerator(inputs, layer_name, patch_height, patch_width, batch_size, file_selection_mode, sample_extraction_mode):
     # Check other file_selection mode and sample_extraction mode
-    list_idx_files = inputs[idx_label][1]
-    print ("Creating Generator: {}".format(idx_label))
+    #list_idx_files = inputs[idx_label][1]
+    #print ("Creating Generator: {}".format(idx_label))
+    for key in inputs.meta.keys():
+        if key == "Image":
+            continue
+        print ("Clean up layer {}".format(key))
+        inputs.delWorkingList(key)
+    print ("Init generator for layer {}".format(layer_name))
+    inputs.initWorkingList(layer_name)
 
     while True:
+        list_idx_files = [i for i in range(len(inputs.meta[layer_name]["working"]))]
         if file_selection_mode == FileSelectionMode.RANDOM:
-            list_idx_files = [np.random.randint(len(inputs[idx_label][1]))]
+            list_idx_files = [np.random.randint(len(inputs.meta[layer_name]["working"]))]
         elif file_selection_mode == FileSelectionMode.SHUFFLE:
             rd.shuffle(list_idx_files)
         for idx_file in list_idx_files:
             if sample_extraction_mode == SampleExtractionMode.RANDOM:
-                yield extractRandomSamples(inputs, idx_file, idx_label, patch_height, patch_width, batch_size, sample_extraction_mode)
+                yield extractRandomSamples(inputs, idx_file, layer_name, patch_height, patch_width, batch_size, sample_extraction_mode)
             elif sample_extraction_mode == SampleExtractionMode.SEQUENTIAL:
-                for i in createGeneratorSequentialExtraction(inputs, idx_file, idx_label, patch_height, patch_width, batch_size):
+                for i in createGeneratorSequentialExtraction(inputs, idx_file, layer_name, patch_height, patch_width, batch_size):
                     yield i
             else:
                 raise Exception(
                     'The sample extraction mode, {} {} does not exist.\n'.format(sample_extraction_mode, type(sample_extraction_mode))
                 )
+        inputs.reloadPendingList(layer_name)
 
-def getTrain(inputs, num_labels, patch_height, patch_width, batch_size, file_selection_mode, sample_extraction_mode):
+def getTrain(inputs, patch_height, patch_width, batch_size, file_selection_mode, sample_extraction_mode):
     generator_labels = []
 
-    for idx_label in inputs:
+    for idx_label in inputs.meta.keys():
         if idx_label == "Image":
             continue
         generator_label = createGenerator(

--- a/Paco_classifier/training_engine_sae.py
+++ b/Paco_classifier/training_engine_sae.py
@@ -124,8 +124,8 @@ def train_msae(
 
     # Create ground_truth
     print("Creating data generators...")
-    generators = getTrain(inputs, num_labels, height, width, batch_size, file_selection_mode, sample_extraction_mode)
-    generators_validation = getTrain(inputs, num_labels, height, width, batch_size, FileSelectionMode.DEFAULT, SampleExtractionMode.RANDOM)
+    generators = getTrain(inputs, height, width, batch_size, file_selection_mode, sample_extraction_mode)
+    generators_validation = getTrain(inputs, height, width, batch_size, FileSelectionMode.DEFAULT, SampleExtractionMode.RANDOM)
 
     # Training loop
     for label in range(num_labels):
@@ -156,7 +156,7 @@ def train_msae(
             verbose=2,
             steps_per_epoch=steps_per_epoch,
             validation_data=generators_validation[label],
-            validation_steps=len(inputs["Image"]),
+            validation_steps=len(inputs.meta["Image"]),
             callbacks=callbacks_list,
             epochs=epochs
         )

--- a/fast_calvo_easy_training.py
+++ b/fast_calvo_easy_training.py
@@ -146,7 +146,7 @@ def main():
 
     # Sanity check
     print ("Start preprocess")
-    layer_dict = preprocess.preprocess(inputs, config.batch_size, config.patch_height, config.patch_width, config.number_samples_per_class)
+    data_container = preprocess.preprocess(inputs, config.batch_size, config.patch_height, config.patch_width, config.number_samples_per_class)
     print ("After pre_training_check")
 
     # Create output models
@@ -156,7 +156,7 @@ def main():
 
     # Call in training function
     status = training.train_msae(
-        inputs=layer_dict,
+        inputs=data_container,
         num_labels=input_ports,
         height=config.patch_height,
         width=config.patch_width,

--- a/tests/testDataContainer.py
+++ b/tests/testDataContainer.py
@@ -1,0 +1,236 @@
+import numpy as np
+from Paco_classifier.preprocess import bytes2Gb
+import Paco_classifier.data_loader as DataLoader
+
+import unittest
+from unittest import mock
+
+import glob
+
+class TestDataContainer(unittest.TestCase):
+    def setUp(self) -> None:
+        self.bool_byte = np.dtype(bool).itemsize
+        self.float_byte = np.dtype(float).itemsize
+        self.uint8_byte = np.dtype(np.uint8).itemsize
+
+        self.images = [p for p in sorted(glob.glob("./dataset/MS73/training/images/*.png"))]
+        self.bg = [p for p in sorted(glob.glob("./dataset/MS73/training/layers/bg/*.png"))]
+        self.neume = [p for p in sorted(glob.glob("./dataset/MS73/training/layers/neume/*.png"))]
+        self.staff = [p for p in sorted(glob.glob("./dataset/MS73/training/layers/staff/*.png"))]
+        self.text = [p for p in sorted(glob.glob("./dataset/MS73/training/layers/text/*.png"))]
+
+    def createContainer(self, ram_limit:int = 4, dum_size:int = 1):
+        container = DataLoader.DataContainer(ram_limit)
+        for img_path, bg_path, neu_path, sta_path, text_path in zip(self.images,
+                                                                    self.bg,
+                                                                    self.neume,
+                                                                    self.staff,
+                                                                    self.text):
+            x_name = img_path.split("/")[-1]                                                        
+
+            img_data = DataLoader.Data(x_name, img_path, size=dum_size)
+            bg_data = DataLoader.Data(x_name, bg_path, size=dum_size)
+            neu_data = DataLoader.Data(x_name, neu_path, size=dum_size)
+            sta_data = DataLoader.Data(x_name, sta_path, size=dum_size)
+            text_data = DataLoader.Data(x_name, text_path, size=dum_size)
+
+            container.addXYPair(x_name, "bg", img_data, bg_data)
+            container.addXYPair(x_name, "neu", img_data, neu_data)
+            container.addXYPair(x_name, "staff", img_data, sta_data)
+            container.addXYPair(x_name, "text", img_data, text_data)
+        return container
+
+    def test_data(self):
+        ram_limit = 4
+        dum_size = 1
+        container = self.createContainer(ram_limit, dum_size)
+
+    def checkPendingWorking(self, container:DataLoader.DataContainer, layer_name:str, 
+                            gt_working_len:int, gt_pending_len:int, gt_total_len: int, prefix:str=""):
+        pending_len = len(container.meta[layer_name]['pending'])
+        working_len = len(container.meta[layer_name]['working'])
+        ram_limit = container.ram_limit
+
+        self.assertEqual(working_len, gt_working_len, f"{prefix}Failed to clear working list with len: {working_len}")
+        self.assertEqual(pending_len, gt_pending_len, f"{prefix}Failed to restore pending list with len: {pending_len}")
+        self.assertEqual(working_len + pending_len, gt_total_len, f"{prefix}pending/working/total: {pending_len}/{working_len}/{gt_total_len}")
+
+        used_ram = 0
+        for working_y in container.meta[layer_name]['working']:
+            self.assertIsNotNone(working_y.img, f"{prefix}Failed to load {working_y.path} in working list.")
+            self.assertNotIn(working_y, container.meta[layer_name]['pending'], f"{prefix}Failed to remove {working_y.path} from pending list.")
+
+            working_x = container.meta['Image'][working_y.x_name]
+            self.assertIsNotNone(working_x.img, f"{prefix}Failed to load {working_x.path} in working list.")
+
+            used_ram += working_y.size
+            used_ram += working_x.size
+        self.assertTrue(used_ram <= ram_limit, f"{prefix}Required RAM {used_ram} exceed limit {ram_limit}")
+
+        for pending_y in container.meta[layer_name]['pending']:
+            self.assertIsNone(pending_y.img, f"{prefix}Failed to del img of {pending_y.path} in pending list.")
+
+            pending_x = container.meta['Image'][pending_y.x_name]
+            self.assertIsNone(pending_x.img, f"{prefix}Failed to del img og {pending_x.path} in pending list.")
+
+    @mock.patch('numpy.load')
+    def test_init_ram_exceed_limit(self, mock_np_load):
+        """
+        All X/Y pair exceed the RAM limit
+        """
+        mock_np_load.return_value = np.zeros((256, 256, 3))
+        # The RAM limit is 2G, but each X/Y pair requires 2*3G = 6G
+        ram_limit = 2
+        dum_size = 3
+        container = self.createContainer(ram_limit, dum_size)
+        total_layer_len = len(container.meta['bg']['pending'])
+        for layer_name in ["bg", "neu", "staff", "text"]:
+            self.assertRaises(ValueError, container.initWorkingList, layer_name)
+
+    @mock.patch('numpy.load')
+    def test_reload_ram_exceed_limit(self, mock_np_load):
+        """
+        When one of the X/Y pair exceed the RAM limit. Reload the prvious working list.
+        """
+        mock_np_load.return_value = np.zeros((256, 256, 3))
+
+        container = DataLoader.DataContainer(ram_limit=11)
+        for idx, dum_size in enumerate([2, 10, 2, 1]):
+        #for idx, dum_size in enumerate([2, 2, 1, 10]):
+            x_name = f"{idx}_{dum_size}"
+            img_data = DataLoader.Data(x_name, f"img_path/{x_name}", size=dum_size)
+            bg_data = DataLoader.Data(x_name, f"bg_path/{x_name}", size=dum_size)
+            neu_data = DataLoader.Data(x_name, f"neu_path/{x_name}", size=dum_size)
+            sta_data = DataLoader.Data(x_name, f"sta_path/{x_name}", size=dum_size)
+            text_data = DataLoader.Data(x_name, f"text_path/{x_name}", size=dum_size)
+
+            container.addXYPair(x_name, "bg", img_data, bg_data)
+            container.addXYPair(x_name, "neu", img_data, neu_data)
+            container.addXYPair(x_name, "staff", img_data, sta_data)
+            container.addXYPair(x_name, "text", img_data, text_data)
+
+        total_layer_len = len(container.meta['bg']['pending'])
+        for layer_name in ["bg", "neu", "staff", "text"]:
+            container.initWorkingList(layer_name)
+            pending_len = len(container.meta[layer_name]['pending'])
+            working_len = len(container.meta[layer_name]['working'])
+            # [2*2G, 2*2G, 2*1G] should be loaded in the working list
+            # [2*10G] should stay in the pending list
+            self.checkPendingWorking(container, layer_name, 3, 1, total_layer_len, "After Init: ")
+
+            # Trying to lad 10*2 Gb into 11G RAM will raise ValueError
+            self.assertRaises(ValueError, container.reloadPendingList, layer_name)
+
+            container.delWorkingList(layer_name)
+            self.checkPendingWorking(container, layer_name, 0, total_layer_len, total_layer_len, "After delete: ")
+
+    @mock.patch('numpy.load')
+    def test_reload_and_fill_ram(self, mock_np_load):
+        """
+        Load more images to fill the RAM.
+        """
+        mock_np_load.return_value = np.zeros((256, 256, 3))
+
+        container = DataLoader.DataContainer(ram_limit=21)
+        for idx, dum_size in enumerate([2, 2, 1, 10]):
+            x_name = f"{idx}_{dum_size}"
+            img_data = DataLoader.Data(x_name, f"img_path/{x_name}", size=dum_size)
+            bg_data = DataLoader.Data(x_name, f"bg_path/{x_name}", size=dum_size)
+            neu_data = DataLoader.Data(x_name, f"neu_path/{x_name}", size=dum_size)
+            sta_data = DataLoader.Data(x_name, f"sta_path/{x_name}", size=dum_size)
+            text_data = DataLoader.Data(x_name, f"text_path/{x_name}", size=dum_size)
+
+            container.addXYPair(x_name, "bg", img_data, bg_data)
+            container.addXYPair(x_name, "neu", img_data, neu_data)
+            container.addXYPair(x_name, "staff", img_data, sta_data)
+            container.addXYPair(x_name, "text", img_data, text_data)
+
+        total_layer_len = len(container.meta['bg']['pending'])
+        for layer_name in ["bg", "neu", "staff", "text"]:
+            # Load 2 * 10G int 21G RAM
+            container.initWorkingList(layer_name)
+            pending_len = len(container.meta[layer_name]['pending'])
+            working_len = len(container.meta[layer_name]['working'])
+            # [2*20G] should be loaded in the working list
+            # [2*1G, 2*2G, 2*2G] should stay in the pending list
+            self.checkPendingWorking(container, layer_name, 1, 3, total_layer_len, "After Init: ")
+
+            # Trying to lad 10*2 Gb into 11G RAM will raise ValueError
+            # Remove 2*20G from the working list, now
+            # [2*1G, 2*2G, 2*2G] should stay in the working list
+            # [2*20G] should be loaded in the pending list
+            container.reloadPendingList(layer_name)
+            self.checkPendingWorking(container, layer_name, 3, 1, total_layer_len, "After Reload: ")
+
+            container.delWorkingList(layer_name)
+            self.checkPendingWorking(container, layer_name, 0, total_layer_len, total_layer_len, "After delete: ")
+
+    @mock.patch('numpy.load')
+    def test_container_init_del(self, mock_np_load):
+        mock_np_load.return_value = np.zeros((256, 256, 3))
+        ram_limit = 5
+        dum_size = 1
+        container = self.createContainer(ram_limit, dum_size)
+
+        total_layer_len = len(container.meta['bg']['pending'])
+        for layer_name in ["bg", "neu", "staff", "text"]:
+            container.initWorkingList(layer_name)
+            pending_len = len(container.meta[layer_name]['pending'])
+            working_len = len(container.meta[layer_name]['working'])
+            self.checkPendingWorking(container, layer_name, working_len, pending_len, total_layer_len, "After Init: ")
+
+            for i in range(5):
+                container.reloadPendingList(layer_name)
+                pending_len = len(container.meta[layer_name]['pending'])
+                working_len = len(container.meta[layer_name]['working'])
+                self.checkPendingWorking(container, layer_name, working_len, pending_len, total_layer_len, "After Init: ")
+
+            container.delWorkingList(layer_name)
+            self.checkPendingWorking(container, layer_name, 0, total_layer_len, total_layer_len, "After delete: ")
+
+    @mock.patch('numpy.load')
+    def test_reload_stuff(self, mock_np_load):
+        """
+        """
+        mock_np_load.return_value = np.zeros((256, 256, 3))
+
+        container = DataLoader.DataContainer(ram_limit=21)
+        random_ram_size = np.random.randint(high=11, low=1, size=20)
+        for idx, dum_size in enumerate(random_ram_size.tolist()):
+            x_name = f"{idx}_{dum_size}"
+            img_data = DataLoader.Data(x_name, f"img_path/{x_name}", size=dum_size)
+            bg_data = DataLoader.Data(x_name, f"bg_path/{x_name}", size=dum_size)
+            neu_data = DataLoader.Data(x_name, f"neu_path/{x_name}", size=dum_size)
+            sta_data = DataLoader.Data(x_name, f"sta_path/{x_name}", size=dum_size)
+            text_data = DataLoader.Data(x_name, f"text_path/{x_name}", size=dum_size)
+
+            container.addXYPair(x_name, "bg", img_data, bg_data)
+            container.addXYPair(x_name, "neu", img_data, neu_data)
+            container.addXYPair(x_name, "staff", img_data, sta_data)
+            container.addXYPair(x_name, "text", img_data, text_data)
+
+        total_layer_len = len(container.meta['bg']['pending'])
+        for layer_name in ["bg", "neu", "staff", "text"]:
+            # Load 2 * 10G int 21G RAM
+            container.initWorkingList(layer_name)
+            pending_len = len(container.meta[layer_name]['pending'])
+            working_len = len(container.meta[layer_name]['working'])
+            # [2*20G] should be loaded in the working list
+            # [2*1G, 2*2G, 2*2G] should stay in the pending list
+            self.checkPendingWorking(container, layer_name, working_len, pending_len, total_layer_len, "After Init: ")
+
+            # Trying to lad 10*2 Gb into 11G RAM will raise ValueError
+            # Remove 2*20G from the working list, now
+            # [2*1G, 2*2G, 2*2G] should stay in the working list
+            # [2*20G] should be loaded in the pending list
+            for i in range(10):
+                container.reloadPendingList(layer_name)
+                pending_len = len(container.meta[layer_name]['pending'])
+                working_len = len(container.meta[layer_name]['working'])
+                self.checkPendingWorking(container, layer_name, working_len, pending_len, total_layer_len, "After Reload: ")
+
+            container.delWorkingList(layer_name)
+            self.checkPendingWorking(container, layer_name, 0, total_layer_len, total_layer_len, "After delete: ")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
When training data (images/layers) can't fit into the RAM limit, load
part of the training data. After doing gradient descent on loaded data,
kick some images/layers out and load new images/layers.