### PR TITLE
Fix #32 Dimension not matched in numpy broadcasting

### DIFF
--- a/Paco_classifier/preprocess.py
+++ b/Paco_classifier/preprocess.py
@@ -41,17 +41,17 @@ def preprocess(inputs, batch_size, patch_height, patch_width, number_samples_per
     """
     Run a bunch of preprocessing steps in this function. Currently we have:
     1. Extract X/Y/W/H from the region mask and crop images and layers first
-    2. The image width/height should be not less than the patch width/height.
-    3. Keep a list to save the indices of nonempty layers. The model is trained on nonempty layers.
-    4. Track the number of empty layers. It should be less than the number of images 
-        (at least one trainable data).
+    2. If the image width/height is less than the patch widht/height, randomly select 
+       pixels and pad to the image to make its width/height equals to 2*patch width/height.
+    3. Preprocess and turn images into (H, W, 3, dtype=float64 between 0.0 and 1.0), layers into
+       (H, W, dtype=bool)
+    4. Write the processed images/layers into .npy file.
+    5. Calculate required RAM size (Gb) of each.
+    6. For each image, save data_loader.Data(path to npy file, RAM size, its unique key)
+    7. For each layer, save data_loader.Data(path to npy file, RAM size, the unique key to access its image)
 
     Return:
-        {<rodan port name>:[[np.ndarray, ...], [int, int, ...]]}
-            A dictionary with the rodan port names ('Image', 'rgba PNG - Layer 0 (Background)', ...)
-            as keys and lists of two lists as their items.
-            1st list: processed/cropped loaded images/layers represented as np.ndarray with shape (W, H, 3, dtype=float) or (W, H, dtyp=bool)
-            2nd list: the indices of nonempty layers. The list is empty in dict['Image']
+        A data_loader.DataContainer class that stores each image/layer pair using data_loader.Data class.
     """
     # Check if batch size is less than number of samples per class
     logging.info("Checking batch size")

--- a/Paco_classifier/preprocess.py
+++ b/Paco_classifier/preprocess.py
@@ -80,7 +80,7 @@ def preprocess(inputs, batch_size, patch_height, patch_width, number_samples_per
         img = cv2.imread(img_path, cv2.IMREAD_COLOR)[Y:Y+H, X:X+W, :]  # RGB, uint8
 
         # Creata data
-        x_name = img_path.split("/")[-1]
+        x_name = img_path.split("/")[-1]+"-{}".format(idx)
         img_W, img_H, img_C = img.shape
         if img_W < patch_width:
             img_W = patch_width*2


### PR DESCRIPTION
Resolve #32 
In Rodan job, the `X` (image) in each `X/Y` (image/layer) pair has the same name (`Image.png`). This cause repeating `x_name` in `data_loader.py:Data`. All `Y`s are mapped to the same `X` with the key `Image.png` and cause the dimension problem. 

This PR generates a unique key for each`X/Y` pair.

### Before This PR
Given `X/Y pairs`: `(image0.png, image0_bg.png), (image1.png, image1_bg.png), (image2.png, image2_bg.png)`

---

`image0_bg.png` uses key `image.png`
`image1_bg.png` uses key `image.png`
`image2_bg.png` uses key `image.png`

key `image.png` maps to `image2.png`, and there's a dimension mismatch problem in `image0_bg.png` and `image1_bg.png`

### In this PR

---

`image0_bg.png` uses key `image.png-0`
`image1_bg.png` uses key `image.png-1`
`image2_bg.png` uses key `image.png-2`

key `image.png-0` maps to `image0.png`
key `image.png-1` maps to `image1.png`
key `image.png-2` maps to `image2.png`